### PR TITLE
Add GitHub action to check links

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,29 @@
+on:
+  push:
+  pull_request:
+      branches:
+        - master
+  workflow_dispatch:
+
+name: Check links
+jobs:
+  check-links:
+    name: Check links
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Clone sources
+        uses: actions/checkout@v2
+        with:
+          path: sources
+
+      - name: Set up Ruby 2.6
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+
+      - name: Check links in Mardown files
+        run: |
+          gem install awesome_bot
+          cd sources
+          awesome_bot README.md --skip-save-results

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           ruby-version: 2.6
 
-      - name: Check links in Mardown files
+      - name: Check links in Markdown files
         run: |
           gem install awesome_bot
           cd sources


### PR DESCRIPTION
Hi,
this pull request add a GitHub actions to check links in the README.

This is just a check with the [awesome-bot](https://github.com/dkhamsing/awesome_bot).

I tried it on my fork, and you can see the result [here](https://github.com/julienloizelet/awesome-ddev/runs/4763602537?check_suite_focus=true)


There is only a 404, lot of 301 because of en ending /, some 302 and 303, and some duplicates URL (called dupes).

For the moment, I call `awesome_bot README.md --skip-save-results` but we could easily add other options : 

- `--allow-dupe`                 Duplicate URLs are allowed
- `--white-list` [urls]          Comma separated URLs to white list
- `--allow` [errors]             Status code errors to allow
- `--allow-redirect`             Redirected URLs are allowed

etc, etc. (please see [the doc](https://github.com/dkhamsing/awesome_bot#command-line) in the awesome_bot repo).

Of course, we could also change the `on` part of the action (I set it to `push`, `pull_request` and `workflow_dispatch`, but we may prefer something else)

Let me know what you think :) 

